### PR TITLE
Added support for double-sided Charuco board

### DIFF
--- a/src/calibrationtool/extrinsicscalibrator.hpp
+++ b/src/calibrationtool/extrinsicscalibrator.hpp
@@ -59,7 +59,8 @@ class ExtrinsicsCalibrator : public QObject, public QRunnable {
       cv::Mat F;
     };
 
-		cv::Mat m_charucoPattern;
+		cv::Mat m_charucoPattern1;
+		cv::Mat m_charucoPattern2;
 		cv::Mat m_detectedPattern;
 
     std::vector<cv::Point3f> m_checkerBoardPoints;

--- a/src/calibrationtool/intrinsicscalibrator.hpp
+++ b/src/calibrationtool/intrinsicscalibrator.hpp
@@ -53,7 +53,8 @@ class IntrinsicsCalibrator : public QObject, public QRunnable {
 		cv::Mat D;
 		};
 
-			cv::Mat m_charucoPattern;
+			cv::Mat m_charucoPattern1;
+			cv::Mat m_charucoPattern2;
 			cv::Mat m_detectedPattern;
 
 		std::vector<cv::Point3f> m_checkerBoardPoints;


### PR DESCRIPTION
Assumes that aruco IDs start from 0 on one side of the board and continue on the other, and that the checkboard pattern is not flipped on the other side - just printed normally (and that therefore the corner IDs need to be flipped when one camera sees one side and another camera sees the other)