### PR TITLE
Add hotkeys for keypoint suppression and skipping

### DIFF
--- a/gui/editor/editorwidget.cpp
+++ b/gui/editor/editorwidget.cpp
@@ -167,7 +167,7 @@ EditorWidget::EditorWidget(QWidget *parent) : QWidget(parent) {
 	connect(this, &EditorWidget::frameChanged, reprojectionWidget, &ReprojectionWidget::calculateReprojectionSlot);
 	connect(this, &EditorWidget::frameChanged, datasetControlWidget, &DatasetControlWidget::frameChangedSlot);
 	connect(this, &EditorWidget::cmdRPressed, keypointWidget, &KeypointWidget::toggleCurrentKeypointSlot);
-	connect(this, &EditorWidget::cmdEPressed, keypointWidget, &KeypointWidget::skipCurrentKeypointSlot);
+	connect(this, &EditorWidget::cmdEPressed, keypointWidget, &KeypointWidget::advanceCurrentKeypointSlot);
 
 	//<-> Relayed Signals
 	connect(datasetControlWidget, &DatasetControlWidget::datasetLoaded, this, &EditorWidget::newSegmentLoaded);

--- a/gui/editor/editorwidget.cpp
+++ b/gui/editor/editorwidget.cpp
@@ -166,6 +166,8 @@ EditorWidget::EditorWidget(QWidget *parent) : QWidget(parent) {
 	connect(this, &EditorWidget::frameChanged, keypointWidget, &KeypointWidget::frameChangedSlot);
 	connect(this, &EditorWidget::frameChanged, reprojectionWidget, &ReprojectionWidget::calculateReprojectionSlot);
 	connect(this, &EditorWidget::frameChanged, datasetControlWidget, &DatasetControlWidget::frameChangedSlot);
+	connect(this, &EditorWidget::cmdRPressed, keypointWidget, &KeypointWidget::toggleCurrentKeypointSlot);
+	connect(this, &EditorWidget::cmdEPressed, keypointWidget, &KeypointWidget::skipCurrentKeypointSlot);
 
 	//<-> Relayed Signals
 	connect(datasetControlWidget, &DatasetControlWidget::datasetLoaded, this, &EditorWidget::newSegmentLoaded);
@@ -456,4 +458,10 @@ void EditorWidget::keyPressEvent(QKeyEvent *e)
 	else if (key == 16777248) {
 			keypointWidget->toggleHideAll();
 		}
+	else if ((key == Qt::Key_R) && (e->modifiers() & Qt::ControlModifier)){
+		emit cmdRPressed();  // will suppress currently selected keypoint
+	}
+	else if ((key == Qt::Key_E) && (e->modifiers() & Qt::ControlModifier)){
+		emit cmdEPressed();  // will skip currently selected keypoint
+	}
 }

--- a/gui/editor/editorwidget.hpp
+++ b/gui/editor/editorwidget.hpp
@@ -54,6 +54,8 @@ class EditorWidget : public QWidget {
 		void errorThresholdChanged(float val);
 		void boneLengthErrorThresholdChanged(float val);
 		void brightnessChanged(int brightnessFactor);
+		void cmdRPressed();  // toggle keypoint suppression
+		void cmdEPressed();  // skip keypoint without any action
 
 	public slots:
 		void splitterMovedSlot(int pos, int index);

--- a/gui/editor/keypointwidget.cpp
+++ b/gui/editor/keypointwidget.cpp
@@ -73,8 +73,7 @@ void KeypointWidget::init() {
 		connect(bodyPartsListWidget, &KeypointListWidget::removeKeypoint, this, &KeypointWidget::removeKeypointSlot);
 		connect(bodyPartsListWidget, &KeypointListWidget::suppressKeypoint, this, &KeypointWidget::suppressKeypointSlot);
 		connect(bodyPartsListWidget, &KeypointListWidget::unsuppressKeypoint, this, &KeypointWidget::unsuppressKeypointSlot);
-		// connect(bodyPartsListWidget, &KeypointListWidget::toggleCurrentKeypoint, this, &KeypointWidget::toggleCurrentKeypointSlot);
-		connect(bodyPartsListWidget, &KeypointListWidget::afterToggleSuppression, this, &KeypointWidget::afterToggleSuppressionSlot);
+		connect(bodyPartsListWidget, &KeypointListWidget::advanceCurrentKeypoint, this, &KeypointWidget::advanceCurrentKeypointSlot);
 
 		for (const auto& bp : Dataset::dataset->bodypartsList()) {
 			QListWidgetItem * bpItem = new QListWidgetItem();
@@ -183,23 +182,7 @@ void KeypointWidget::toggleCurrentKeypointSlot() {
 	keypointList->toggleCurrentKeypointSuppression();
 }
 
-void KeypointWidget::afterToggleSuppressionSlot() {
-	
-	KeypointListWidget* keypointList = keypointListMap[m_currentEntity];
-
-	// advance the row to the next keypoint, if possible
-	if (keypointList->currentRow() < keypointList->count()-1) {
-		keypointList->setCurrentRow(keypointList->currentRow()+1);
-		
-		// update the viewer accordingly
-		QColor color = colorMap->getColor(keypointList->currentRow(), keypointList->count());
-		m_currentBodypart = keypointList->item(keypointList->currentRow())->text();
-		emit currentBodypartChanged(m_currentBodypart, color);
-		emit updateViewer();
-	}
-}
-
-void KeypointWidget::skipCurrentKeypointSlot(){
+void KeypointWidget::advanceCurrentKeypointSlot(){
 	// figure out which keypointList is currently active
 	KeypointListWidget* keypointList = keypointListMap[m_currentEntity];
 	

--- a/gui/editor/keypointwidget.hpp
+++ b/gui/editor/keypointwidget.hpp
@@ -40,11 +40,29 @@ class KeypointListWidget : public QListWidget {
 		void clearSupressed() {
 			m_suppressedList.clear();
 		}
+		// bool isSuppressed(int row) {
+			// return m_suppressedList.contains(row);
+		// }
+
+		void toggleCurrentKeypointSuppression(){
+			int current = this->currentRow();
+			bool isSuppressed = m_suppressedList.contains(current);
+			if (isSuppressed) {
+				m_suppressedList.removeAll(current);
+				emit unsuppressKeypoint(current);
+			}
+			else {
+				m_suppressedList.append(current);
+				emit suppressKeypoint(current);
+			}
+			emit afterToggleSuppression();
+		}
 
 	signals:
 		void removeKeypoint(int row);
 		void suppressKeypoint(int row);
 		void unsuppressKeypoint(int row);
+		void afterToggleSuppression();
 
 	private:
 		QList<int> m_suppressedList = {};
@@ -131,6 +149,9 @@ class KeypointWidget : public QWidget {
 		void unsuppressKeypointSlot(int row);
 		void frameChangedSlot(int currentImgSetIndex, int currentFrameIndex);
 		void setKeypointsFromDatasetSlot();
+		void toggleCurrentKeypointSlot();
+		void afterToggleSuppressionSlot();
+		void skipCurrentKeypointSlot();
 
 	private:
 		ColorMap *colorMap;

--- a/gui/editor/keypointwidget.hpp
+++ b/gui/editor/keypointwidget.hpp
@@ -55,14 +55,14 @@ class KeypointListWidget : public QListWidget {
 				m_suppressedList.append(current);
 				emit suppressKeypoint(current);
 			}
-			emit afterToggleSuppression();
+			emit advanceCurrentKeypoint();
 		}
 
 	signals:
 		void removeKeypoint(int row);
 		void suppressKeypoint(int row);
 		void unsuppressKeypoint(int row);
-		void afterToggleSuppression();
+		void advanceCurrentKeypoint();
 
 	private:
 		QList<int> m_suppressedList = {};
@@ -150,8 +150,7 @@ class KeypointWidget : public QWidget {
 		void frameChangedSlot(int currentImgSetIndex, int currentFrameIndex);
 		void setKeypointsFromDatasetSlot();
 		void toggleCurrentKeypointSlot();
-		void afterToggleSuppressionSlot();
-		void skipCurrentKeypointSlot();
+		void advanceCurrentKeypointSlot();
 
 	private:
 		ColorMap *colorMap;


### PR DESCRIPTION
Hi there -- thanks for creating and maintaining this tool, I've been enjoying using it. We sometimes have long lists of keypoints, only some of which are visible in a given frame, and so I've been wanting a keyboard shortcut to suppress keypoints, instead of having to click through the context menu on each one. Here's my first shot. (ChatGPT was a big help in writing the code for this!) It compiles and seems to work well for me.

There are two changes:
Cmd-R will toggle suppress / unsuppress for the selected keypoint, and move to the next keypoint in the list.
Cmd-E wills simply move to the next keypoint without changing anything.

I believe I was able to do this in such a way that this doesn't interact with anything else in the code (other than updating the viewer when necessary), so hopefully it's a straightforward review.
